### PR TITLE
Fixed branch ID validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.2.5] - 2023-11-02
+
+### Fixed
+
+- Fixed validation of the [branch ID](https://neon.tech/docs/manage/branches#view-branches).
+
 ## [v0.2.4] - 2023-10-26
 
 ### Fixed

--- a/internal/provider/resource_branch.go
+++ b/internal/provider/resource_branch.go
@@ -222,5 +222,5 @@ func resourceBranchImport(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func isValidBranchID(s string) bool {
-	return strings.HasPrefix("br-", s)
+	return strings.HasPrefix(s, "br-")
 }

--- a/internal/provider/resource_branch.go
+++ b/internal/provider/resource_branch.go
@@ -222,5 +222,6 @@ func resourceBranchImport(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func isValidBranchID(s string) bool {
-	return strings.HasPrefix(s, "br-")
+	const prefix = "br-"
+	return strings.HasPrefix(s, prefix) && len(strings.TrimPrefix(s, prefix)) > 0
 }

--- a/internal/provider/resource_branch_test.go
+++ b/internal/provider/resource_branch_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import "testing"
+
+func Test_isValidBranchID(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				s: "br-foo123b",
+			},
+			want: true,
+		},
+		{
+			name: "unhappy path: no id post-prefix",
+			args: args{
+				s: "br-",
+			},
+			want: false,
+		},
+		{
+			name: "unhappy path: no prefix",
+			args: args{
+				s: "qux",
+			},
+			want: false,
+		},
+		{
+			name: "unhappy path: empty string",
+			args: args{
+				s: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidBranchID(tt.args.s); got != tt.want {
+				t.Errorf("isValidBranchID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #55
Extends #56 

## What changed

- Fixed branch ID validation

## Why do we need it

- To align with the [Neon specs](https://neon.tech/docs/manage/branches#view-branches)
