### PR TITLE
Fixed the behaviour of the `neon_project` when it comes to tracking the default role and database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.0] - 2024-03-09
+
+### Fixed
+
+- [[#83](https://github.com/kislerdm/terraform-provider-neon/issues/83)] Fixed the state management of the project's 
+default branch, role, database and endpoint.
+
 ## [v0.4.1] - 2024-02-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.5.0] - 2024-03-09
 
+### Added
+
+- Added the read-only attribute `default_endpoint_id` to the resource `neon_project`. 
+
 ### Fixed
 
 - [[#83](https://github.com/kislerdm/terraform-provider-neon/issues/83)] Fixed the state management of the project's 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -99,6 +99,7 @@ The zero value per attributed means 'unlimited'. (see [below for nested schema](
 - `database_password` (String, Sensitive) Default database access password.
 - `database_user` (String) Default database role.
 - `default_branch_id` (String) Default branch ID.
+- `default_endpoint_id` (String) Default endpoint ID.
 - `id` (String) Project ID.
 
 <a id="nestedblock--branch"></a>
@@ -106,9 +107,12 @@ The zero value per attributed means 'unlimited'. (see [below for nested schema](
 
 Optional:
 
-- `database_name` (String) The database name. If not specified, the default database name will be used.
-- `name` (String) The branch name. If not specified, the default branch name will be used.
-- `role_name` (String) The role name. If not specified, the default role name will be used.
+- `database_name` (String) The name of the default database provisioned upon creation of new project. It's owned by the default role (`role_name`).
+If not specified, the default database name will be used.
+- `name` (String) The name of the default branch provisioned upon creation of new project. 
+If not specified, the default branch name will be used.
+- `role_name` (String) The name of the default role provisioned upon creation of new project.
+If not specified, the default role name will be used.
 
 Read-Only:
 
@@ -126,6 +130,10 @@ Optional:
 The value 0 means use the global default.
 The value -1 means never suspend. The default value is 300 seconds (5 minutes).
 The maximum value is 604800 seconds (1 week)
+
+Read-Only:
+
+- `id` (String) Endpoint ID.
 
 
 <a id="nestedblock--quota"></a>

--- a/internal/provider/resource_endpoint.go
+++ b/internal/provider/resource_endpoint.go
@@ -10,6 +10,8 @@ import (
 	neon "github.com/kislerdm/neon-sdk-go"
 )
 
+const endpointTypeRW = "read_write"
+
 func resourceEndpoint() *schema.Resource {
 	return &schema.Resource{
 		Description: `Project Endpoint. See details: https://neon.tech/docs/manage/endpoints/
@@ -45,7 +47,7 @@ func resourceEndpoint() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "read_write",
+				Default:     endpointTypeRW,
 				Description: `Access type. **Note** that "read_write" is the only supported type yet.`,
 				ValidateFunc: func(d interface{}, k string) (warn []string, errs []error) {
 					switch v := d.(string); v {

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -157,6 +157,11 @@ See details: https://neon.tech/docs/introduction/logical-replication
 				Sensitive:   true,
 				Description: "Default connection uri. **Note** that it contains access credentials.",
 			},
+			"default_endpoint_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Default endpoint ID.",
+			},
 		},
 	}
 }
@@ -252,7 +257,7 @@ var schemaDefaultEndpointSettings = &schema.Schema{
 	Optional: true,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"default_endpoint_id": {
+			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Endpoint ID.",
@@ -489,7 +494,7 @@ func updateStateProject(
 	}
 
 	if dbConnectionInfo.endpointID != "" {
-		defaultEndpointSettings["default_endpoint_id"] = dbConnectionInfo.endpointID
+		defaultEndpointSettings["id"] = dbConnectionInfo.endpointID
 		if err := d.Set("default_endpoint_settings", []interface{}{defaultEndpointSettings}); err != nil {
 			return err
 		}
@@ -562,6 +567,10 @@ func updateStateProject(
 	}
 
 	if err := d.Set("connection_uri", dbConnectionInfo.connectionURI()); err != nil {
+		return err
+	}
+
+	if err := d.Set("default_endpoint_id", dbConnectionInfo.endpointID); err != nil {
 		return err
 	}
 

--- a/internal/provider/stub.go
+++ b/internal/provider/stub.go
@@ -9,6 +9,7 @@ import (
 
 type sdkClientStub struct {
 	stubProjectPermission
+	stubProjectRolePassword
 	req interface{}
 	err error
 }
@@ -42,11 +43,16 @@ func (s *sdkClientStub) CreateProject(cfg neon.ProjectCreateRequest) (neon.Creat
 	return neon.CreatedProject{}, s.err
 }
 
-func (s *sdkClientStub) GetProjectBranchRolePassword(_ string, _ string, _ string) (neon.RolePasswordResponse, error) {
+type stubProjectRolePassword struct {
+	Password string
+	err      error
+}
+
+func (s *stubProjectRolePassword) GetProjectBranchRolePassword(_ string, _ string, _ string) (neon.RolePasswordResponse, error) {
 	if s.err != nil {
 		return neon.RolePasswordResponse{}, s.err
 	}
-	return neon.RolePasswordResponse{}, nil
+	return neon.RolePasswordResponse{Password: s.Password}, nil
 }
 
 type stubProjectPermission struct {


### PR DESCRIPTION
Resolves #83 

## What changed

- The behaviour of the `neon_project` was fixed to keep track of the default role, database, branch and endpoint which were created as part of the [project create](https://api-docs.neon.tech/reference/createproject) operation.
- Added `default_branch_id` as the read-only attribute of the `neon_project` resource.
- Documentation was refactored for clarity.

## Why do we need it

To ensure desired behaviour of the `neon_project` state management.
