### PR TITLE
Make the default value for retention window consistent with Neon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.6.4] - Unreleased
+## [v0.7.0] - Unreleased
 
 ### Added
 
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated dependencies:
   - Neon Go SDK: [v0.9.0](https://github.com/kislerdm/neon-sdk-go/compare/v0.6.1...v0.9.0)
-
+- **[BREAKING]** [#113](https://github.com/kislerdm/terraform-provider-neon/issues/113)] Set the default retention
+  window to 1 day to avoid inconsistency with Neon.
 
 ## [v0.6.3] - 2024-10-05
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -110,7 +110,7 @@ Sets wal_level=logical for all compute endpoints in this project.
 All active endpoints will be suspended. Once enabled, logical replication cannot be disabled.
 See details: https://neon.tech/docs/introduction/logical-replication
 - `history_retention_seconds` (Number) The number of seconds to retain the point-in-time restore (PITR) backup history for this project.
-Default: 7 days, see https://neon.tech/docs/reference/glossary#point-in-time-restore.
+Default: 1 day, see https://neon.tech/docs/reference/glossary#point-in-time-restore.
 - `name` (String) Project name.
 - `org_id` (String) Identifier of the organisation to which this project belongs.
 - `pg_version` (Number) Postgres version
@@ -128,7 +128,7 @@ of data stored in a branch, so it is not reset.
 The zero value per attributed means 'unlimited'. (see [below for nested schema](#nestedblock--quota))
 - `region_id` (String) Deployment region: https://neon.tech/docs/introduction/regions
 - `store_password` (String) Set to 'yes' to activate, 'no' to deactivate explicitly, and omit to keep the default value.
-Whether or not passwords are stored for roles in the Neon project. 
+Whether or not passwords are stored for roles in the Neon project.
 Storing passwords facilitates access to Neon features that require authorization.
 
 ### Read-Only

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -14,10 +14,10 @@ import (
 	"github.com/kislerdm/terraform-provider-neon/internal/types"
 )
 
-const providerDefaultHistoryRetentionSeconds = int(time.Hour/time.Second) * 24 * 7
+const providerDefaultHistoryRetentionSeconds = int(time.Hour/time.Second) * 24
 
 func newStoreProjectPasswordDefault() *schema.Schema {
-	o := types.NewOptionalTristateBool(`Whether or not passwords are stored for roles in the Neon project. 
+	o := types.NewOptionalTristateBool(`Whether or not passwords are stored for roles in the Neon project.
 Storing passwords facilitates access to Neon features that require authorization.`, false)
 	o.Default = types.ValTrue
 	return o
@@ -81,7 +81,7 @@ API: https://api-docs.neon.tech/reference/createproject`,
 				Default:      providerDefaultHistoryRetentionSeconds,
 				ValidateFunc: intValidationNotNegative,
 				Description: `The number of seconds to retain the point-in-time restore (PITR) backup history for this project.
-Default: 7 days, see https://neon.tech/docs/reference/glossary#point-in-time-restore.`,
+Default: 1 day, see https://neon.tech/docs/reference/glossary#point-in-time-restore.`,
 			},
 			"compute_provisioner": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Since the Neon docs have a different default, it's worth not defaulting in the provider to a different value. Fixes #113.