### PR TITLE
refactor: implement project listing with pagination while importing

### DIFF
--- a/provider/resource_branch.go
+++ b/provider/resource_branch.go
@@ -243,8 +243,6 @@ func resourceBranchImport(ctx context.Context, d *schema.ResourceData, meta inte
 		return nil, errors.New("branch ID " + d.Id() + " is not valid")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel()
 	var projects []neon.ProjectListItem
 	var cursor *string
 	for {

--- a/provider/resource_branch.go
+++ b/provider/resource_branch.go
@@ -250,11 +250,11 @@ func resourceBranchImport(ctx context.Context, d *schema.ResourceData, meta inte
 		if err != nil {
 			return nil, err
 		}
-		projects = append(projects, resp.Projects...)
-		if resp.PaginationResponse.Pagination == nil || (cursor != nil && *cursor == resp.PaginationResponse.Pagination.Cursor) {
+		if len(resp.Projects) == 0 || resp.PaginationResponse.Pagination == nil || (cursor != nil && *cursor == resp.PaginationResponse.Pagination.Cursor) {
 			tflog.Trace(ctx, "listing projects finished")
 			break
 		}
+		projects = append(projects, resp.Projects...)
 		cursor = &resp.Pagination.Cursor
 	}
 

--- a/provider/resource_endpoint.go
+++ b/provider/resource_endpoint.go
@@ -291,12 +291,17 @@ func resourceEndpointImport(ctx context.Context, d *schema.ResourceData, meta in
 	var projects []neon.ProjectListItem
 	var cursor *string
 	for {
+		tflog.Trace(ctx, "listing batch of projects")
 		resp, err := meta.(*neon.Client).ListProjects(cursor, nil, nil, nil, nil)
 		if err != nil {
 			return nil, err
 		}
 		projects = append(projects, resp.Projects...)
-		if resp.PaginationResponse.Pagination == nil {
+		if len(projects) == 0 {
+			tflog.Trace(ctx, "listing projects finished")
+		}
+		if resp.PaginationResponse.Pagination == nil || (cursor != nil && *cursor == resp.PaginationResponse.Pagination.Cursor) {
+			tflog.Trace(ctx, "listing projects finished")
 			break
 		}
 		cursor = &resp.Pagination.Cursor

--- a/provider/resource_endpoint.go
+++ b/provider/resource_endpoint.go
@@ -296,11 +296,11 @@ func resourceEndpointImport(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return nil, err
 		}
-		projects = append(projects, resp.Projects...)
-		if resp.PaginationResponse.Pagination == nil || (cursor != nil && *cursor == resp.PaginationResponse.Pagination.Cursor) {
+		if len(resp.Projects) == 0 || resp.PaginationResponse.Pagination == nil || (cursor != nil && *cursor == resp.PaginationResponse.Pagination.Cursor) {
 			tflog.Trace(ctx, "listing projects finished")
 			break
 		}
+		projects = append(projects, resp.Projects...)
 		cursor = &resp.Pagination.Cursor
 	}
 

--- a/provider/resource_endpoint.go
+++ b/provider/resource_endpoint.go
@@ -297,9 +297,6 @@ func resourceEndpointImport(ctx context.Context, d *schema.ResourceData, meta in
 			return nil, err
 		}
 		projects = append(projects, resp.Projects...)
-		if len(projects) == 0 {
-			tflog.Trace(ctx, "listing projects finished")
-		}
 		if resp.PaginationResponse.Pagination == nil || (cursor != nil && *cursor == resp.PaginationResponse.Pagination.Cursor) {
 			tflog.Trace(ctx, "listing projects finished")
 			break


### PR DESCRIPTION
This addresses cases when a user has more projects than the default pagination provides. Importing branches and endpoints are based on listing available projects, and thus branches and endpoints of projects N+1, N+2, ... where N is the default pagination limit are unavailable for import.

The listing API is built in the following way: when building the whole list of projects, must one FIRST check that the stop condition is true and if not, add it to the resulting list of projects.