### PR TITLE
Add support for blocking public connections to project endpoints

### DIFF
--- a/examples/resources/neon_project/resource.tf
+++ b/examples/resources/neon_project/resource.tf
@@ -62,6 +62,15 @@ resource "neon_project" "example_with_allowed_ips_protected_branch_only" {
   allowed_ips_protected_branches_only = "yes"
 }
 
+### Block public connections to the project's endpoints
+# Note that the feature is only available to the users of the Scale plans:
+# https://neon.tech/docs/introduction/ip-allow
+resource "neon_project" "example_with_blocked_public_connections" {
+  name = "my-project-with-blocked-public-connections"
+
+  block_public_connections = "yes"
+}
+
 ### Create project in the organisation
 resource "neon_project" "example_in_org" {
   name   = "myproject"


### PR DESCRIPTION
👋 Looks like support for blocking internet connections is not available in the terraform module. I can workaround the issue by setting the ip address to `127.0.0.1` (or just use the UI) but I would like to use official means via terraform.

First time modifying a terraform plugin so apologies if it looks weird.

Have not done an E2E test, just unit tests.