### PR TITLE
Fix VPC endpoint assignment import to use composite ID

### DIFF
--- a/docs/resources/vpc_endpoint_assignment.md
+++ b/docs/resources/vpc_endpoint_assignment.md
@@ -41,7 +41,7 @@ resource "neon_vpc_endpoint_assignment" "example" {
 
 ## Import
 
-The VPC endpoint assignment to organization can be imported to the terraform state by its identifier.
+The VPC endpoint assignment to organization can be imported to the terraform state using a composite identifier in the format: `{{.OrgID}}/{{.RegionID}}/{{.VPCEndpointID}}`
 
 Import using the [import block](https://developer.hashicorp.com/terraform/language/import):
 
@@ -50,12 +50,12 @@ For example:
 ```hcl
 import {
   to = neon_vpc_endpoint_assignment.example
-  id = "vpce-1234567890abcdef0"
+  id = "org-foo-bar-01234567/aws-us-east-1/vpce-1234567890abcdef0"
 }
 ```
 
 Import using the command `terraform import`:
 
 ```commandline
-terraform import neon_vpc_endpoint_assignment.example vpce-1234567890abcdef0
+terraform import neon_vpc_endpoint_assignment.example org-foo-bar-01234567/aws-us-east-1/vpce-1234567890abcdef0
 ```

--- a/provider/resource_vpc_endpoint_assignment.go
+++ b/provider/resource_vpc_endpoint_assignment.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,7 +51,7 @@ See details: https://neon.tech/docs/guides/neon-private-networking#enable-privat
 }
 
 func resourceVPCEndpointAssignmentCreate(_ context.Context, d *schema.ResourceData, meta interface{}) error {
-	err := meta.(*neon.Client).AssignOrganizationVPCEndpoint(
+	err := meta.(sdkVPCEndpoint).AssignOrganizationVPCEndpoint(
 		d.Get("org_id").(string),
 		d.Get("region_id").(string),
 		d.Get("vpc_endpoint_id").(string),
@@ -64,7 +66,7 @@ func resourceVPCEndpointAssignmentCreate(_ context.Context, d *schema.ResourceDa
 }
 
 func resourceVPCEndpointAssignmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) error {
-	resp, err := meta.(*neon.Client).GetOrganizationVPCEndpointDetails(
+	resp, err := meta.(sdkVPCEndpoint).GetOrganizationVPCEndpointDetails(
 		d.Get("org_id").(string),
 		d.Get("region_id").(string),
 		d.Get("vpc_endpoint_id").(string),
@@ -76,7 +78,7 @@ func resourceVPCEndpointAssignmentRead(_ context.Context, d *schema.ResourceData
 }
 
 func resourceVPCEndpointAssignmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) error {
-	err := meta.(*neon.Client).DeleteOrganizationVPCEndpoint(
+	err := meta.(sdkVPCEndpoint).DeleteOrganizationVPCEndpoint(
 		d.Get("org_id").(string),
 		d.Get("region_id").(string),
 		d.Get("vpc_endpoint_id").(string),
@@ -100,8 +102,48 @@ func resourceVPCEndpointAssignmentDeleteRetry(ctx context.Context, d *schema.Res
 }
 
 func resourceVPCEndpointAssignmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	r, err := parseVPCEndpointAssignmentID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	setResourceAttrsFromVPCEndpointAssignmentID(d, r)
 	if err := resourceVPCEndpointAssignmentRead(ctx, d, meta); err != nil {
 		return nil, err
 	}
+
+	// Set ID to vpc_endpoint_id only for backwards compatibility with existing state
+	d.SetId(r.VPCEndpointID)
+
 	return []*schema.ResourceData{d}, nil
+}
+
+type sdkVPCEndpoint interface {
+	AssignOrganizationVPCEndpoint(string, string, string, neon.VPCEndpointAssignment) error
+	GetOrganizationVPCEndpointDetails(string, string, string) (neon.VPCEndpointDetails, error)
+	DeleteOrganizationVPCEndpoint(string, string, string) error
+}
+
+type vpcEndpointAssignmentID struct {
+	OrgID, RegionID, VPCEndpointID string
+}
+
+func setResourceAttrsFromVPCEndpointAssignmentID(d *schema.ResourceData, r vpcEndpointAssignmentID) {
+	_ = d.Set("org_id", r.OrgID)
+	_ = d.Set("region_id", r.RegionID)
+	_ = d.Set("vpc_endpoint_id", r.VPCEndpointID)
+}
+
+func parseVPCEndpointAssignmentID(s string) (vpcEndpointAssignmentID, error) {
+	spl := strings.Split(s, "/")
+	if len(spl) != 3 {
+		return vpcEndpointAssignmentID{}, errors.New(
+			"ID of this resource type shall follow the template: {{.OrgID}}/{{.RegionID}}/{{.VPCEndpointID}}",
+		)
+	}
+	return vpcEndpointAssignmentID{
+		OrgID:         spl[0],
+		RegionID:      spl[1],
+		VPCEndpointID: spl[2],
+	}, nil
 }

--- a/provider/resource_vpc_endpoint_assignment_test.go
+++ b/provider/resource_vpc_endpoint_assignment_test.go
@@ -1,0 +1,177 @@
+//go:build !acceptance
+// +build !acceptance
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	neon "github.com/kislerdm/neon-sdk-go"
+)
+
+func Test_resourceVPCEndpointAssignmentImport(t *testing.T) {
+	if os.Getenv("TF_ACC") == "1" {
+		t.Skip("acceptance tests are running")
+	}
+
+	t.Parallel()
+
+	const (
+		orgID         = "org-test-123"
+		regionID      = "aws-eu-central-1"
+		vpcEndpointID = "vpce-abcdef123456"
+		label         = "my-vpc-endpoint"
+		compositeID   = orgID + "/" + regionID + "/" + vpcEndpointID
+	)
+
+	t.Run("shall import the vpc endpoint assignment given composite id", func(t *testing.T) {
+		resource := resourceVPCEndpointAssignment()
+		definition := resource.TestResourceData()
+		definition.SetId(compositeID)
+
+		meta := &sdkClientStub{
+			stubVPCEndpoint: stubVPCEndpoint{
+				VPCEndpointDetails: neon.VPCEndpointDetails{
+					Label: label,
+				},
+			},
+		}
+
+		resources, err := resourceVPCEndpointAssignmentImport(context.TODO(), definition, meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		d := resources[0]
+
+		if got := d.Get("org_id").(string); got != orgID {
+			t.Errorf("org_id = %q, want %q", got, orgID)
+		}
+		if got := d.Get("region_id").(string); got != regionID {
+			t.Errorf("region_id = %q, want %q", got, regionID)
+		}
+		if got := d.Get("vpc_endpoint_id").(string); got != vpcEndpointID {
+			t.Errorf("vpc_endpoint_id = %q, want %q", got, vpcEndpointID)
+		}
+		if got := d.Get("label").(string); got != label {
+			t.Errorf("label = %q, want %q", got, label)
+		}
+
+		// Verify ID is set to vpc_endpoint_id only (not composite) for backwards compatibility
+		if got := d.Id(); got != vpcEndpointID {
+			t.Errorf("id = %q, want %q (vpc_endpoint_id only for backwards compatibility)", got, vpcEndpointID)
+		}
+	})
+
+	t.Run("shall fail with invalid composite id", func(t *testing.T) {
+		resource := resourceVPCEndpointAssignment()
+		definition := resource.TestResourceData()
+		definition.SetId("invalid-id")
+
+		meta := &sdkClientStub{}
+
+		_, err := resourceVPCEndpointAssignmentImport(context.TODO(), definition, meta)
+		if err == nil {
+			t.Fatal("error expected")
+		}
+	})
+
+	t.Run("shall fail when api returns error", func(t *testing.T) {
+		resource := resourceVPCEndpointAssignment()
+		definition := resource.TestResourceData()
+		definition.SetId(compositeID)
+
+		meta := &sdkClientStub{
+			stubVPCEndpoint: stubVPCEndpoint{
+				err: errors.New("api error"),
+			},
+		}
+
+		_, err := resourceVPCEndpointAssignmentImport(context.TODO(), definition, meta)
+		if err == nil {
+			t.Fatal("error expected")
+		}
+	})
+}
+
+func TestParseVPCEndpointAssignmentID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    vpcEndpointAssignmentID
+		wantErr bool
+	}{
+		{
+			name:  "valid composite ID",
+			input: "org-foo-bar-01234567/aws-us-east-1/vpce-1234567890abcdef0",
+			want: vpcEndpointAssignmentID{
+				OrgID:         "org-foo-bar-01234567",
+				RegionID:      "aws-us-east-1",
+				VPCEndpointID: "vpce-1234567890abcdef0",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing region",
+			input:   "org-foo/vpce-123",
+			wantErr: true,
+		},
+		{
+			name:    "just vpc endpoint ID",
+			input:   "vpce-1234567890abcdef0",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVPCEndpointAssignmentID(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseVPCEndpointAssignmentID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseVPCEndpointAssignmentID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetResourceAttrsFromVPCEndpointAssignmentID(t *testing.T) {
+	// Create a ResourceData using the VPC endpoint assignment schema
+	resourceSchema := map[string]*schema.Schema{
+		"org_id":          {Type: schema.TypeString},
+		"region_id":       {Type: schema.TypeString},
+		"vpc_endpoint_id": {Type: schema.TypeString},
+		"label":           {Type: schema.TypeString},
+	}
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{})
+
+	// Parse a composite ID and set attributes
+	id := vpcEndpointAssignmentID{
+		OrgID:         "org-test-123",
+		RegionID:      "aws-eu-central-1",
+		VPCEndpointID: "vpce-abcdef123456",
+	}
+	setResourceAttrsFromVPCEndpointAssignmentID(d, id)
+
+	// Verify attributes were set correctly
+	if got := d.Get("org_id").(string); got != id.OrgID {
+		t.Errorf("org_id = %q, want %q", got, id.OrgID)
+	}
+	if got := d.Get("region_id").(string); got != id.RegionID {
+		t.Errorf("region_id = %q, want %q", got, id.RegionID)
+	}
+	if got := d.Get("vpc_endpoint_id").(string); got != id.VPCEndpointID {
+		t.Errorf("vpc_endpoint_id = %q, want %q", got, id.VPCEndpointID)
+	}
+}

--- a/provider/stub.go
+++ b/provider/stub.go
@@ -11,10 +11,31 @@ import (
 type sdkClientStub struct {
 	stubProjectPermission
 	stubProjectRolePassword
+	stubVPCEndpoint
 	mockOpsReader
 
 	req interface{}
 	err error
+}
+
+type stubVPCEndpoint struct {
+	VPCEndpointDetails neon.VPCEndpointDetails
+	err                error
+}
+
+func (s *stubVPCEndpoint) AssignOrganizationVPCEndpoint(_, _, _ string, _ neon.VPCEndpointAssignment) error {
+	return s.err
+}
+
+func (s *stubVPCEndpoint) GetOrganizationVPCEndpointDetails(_, _, _ string) (neon.VPCEndpointDetails, error) {
+	if s.err != nil {
+		return neon.VPCEndpointDetails{}, s.err
+	}
+	return s.VPCEndpointDetails, nil
+}
+
+func (s *stubVPCEndpoint) DeleteOrganizationVPCEndpoint(_, _, _ string) error {
+	return s.err
 }
 
 func (s *sdkClientStub) UpdateProject(_ string, cfg neon.ProjectUpdateRequest) (neon.UpdateProjectRespObj, error) {


### PR DESCRIPTION
The import function for `neon_vpc_endpoint_assignment` previously accepted only the `vpc_endpoint_id`. However, the Read function requires `org_id`, `region_id`, and `vpc_endpoint_id` to fetch resource details from the API. This prevented these resources from being imported.

This change updates the import to accept a composite ID in the format `org_id/region_id/vpc_endpoint_id`:

```hcl
import {
  to = neon_vpc_endpoint_assignment.example
  id = "org-foo-bar-01234567/aws-us-east-1/vpce-1234567890abcdef0"
}
```

The state ID remains set to `vpc_endpoint_id` only after import, preserving backwards compatibility with existing state files.

I was able to use these changes locally to successfully import VPC endpoint assignment resources.

Unit tests are included for the new helper functions and import logic.