### PR TITLE
fix: only send maintenanceWindow on update when changed

### DIFF
--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -884,22 +884,24 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	var maintenanceWindow = new(neon.MaintenanceWindow)
-	if v, ok := d.GetOk("maintenance_window"); ok {
-		if len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && len(v) > 0 {
-				weekdaysRaw := v["weekdays"].([]interface{})
-				var weekdays = make([]int, len(weekdaysRaw))
-				for i, weekday := range weekdaysRaw {
-					weekdays[i] = weekday.(int)
+	var maintenanceWindow *neon.MaintenanceWindow
+	if d.HasChange("maintenance_window") {
+		if v, ok := d.GetOk("maintenance_window"); ok {
+			if len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+				if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && len(v) > 0 {
+					weekdaysRaw := v["weekdays"].([]interface{})
+					var weekdays = make([]int, len(weekdaysRaw))
+					for i, weekday := range weekdaysRaw {
+						weekdays[i] = weekday.(int)
+					}
+					maintenanceWindow = &neon.MaintenanceWindow{
+						Weekdays:  weekdays,
+						StartTime: v["start_time"].(string),
+						EndTime:   v["end_time"].(string),
+					}
 				}
-				maintenanceWindow.Weekdays = weekdays
-				maintenanceWindow.StartTime = v["start_time"].(string)
-				maintenanceWindow.EndTime = v["end_time"].(string)
 			}
 		}
-	} else {
-		maintenanceWindow = nil
 	}
 
 	req.Project.Settings = &neon.ProjectSettingsData{


### PR DESCRIPTION
## Problem

On Neon's free plan, the `maintenance_window` feature is not available. Projects are automatically assigned a default maintenance window by Neon, and users cannot modify it.

When testing the Neon API directly, I discovered that sending `maintenanceWindow` in an update request (even with empty/default values) causes the API to reject the request with:

```
maintenance window feature is not available for your account
```

The current provider implementation always populates `maintenanceWindow` from state during updates - even when the user hasn't changed it. This means **any** project update (e.g., just renaming the project) fails for free plan users.

## Root Cause

In `resourceProjectUpdate()`, the code initializes `maintenanceWindow` with `new(neon.MaintenanceWindow)` and always populates it from state:

```go
var maintenanceWindow = new(neon.MaintenanceWindow)
if v, ok := d.GetOk("maintenance_window"); ok {
    // Always reads from state and populates the struct
}
```

This results in the field always being sent to the API, triggering the error for accounts without the feature.

## Solution

Only include `maintenanceWindow` in the update request when the user explicitly changes it, using `d.HasChange()`:

```go
var maintenanceWindow *neon.MaintenanceWindow  // nil by default
if d.HasChange("maintenance_window") {
    // Only populate if user actually changed it
}
```

This matches the existing pattern used for `quota` (lines 878-885), which also uses `d.HasChange()` to conditionally include the field.

## Impact

- **Free plan users**: Can now update projects without errors
- **Paid plan users**: No change in behavior - maintenance window is only sent when explicitly modified
- **Backwards compatible**: No breaking changes to existing functionality

## Testing

- `make test` passes
- `make build` succeeds
- Verified locally: project updates now succeed on free plan accounts