### PR TITLE
Provider errors on 404 when Neon resource is deleted outside of Terraform

### DIFF
--- a/provider/resource_branch.go
+++ b/provider/resource_branch.go
@@ -217,6 +217,7 @@ func resourceBranchRead(ctx context.Context, d *schema.ResourceData, meta interf
 	resp, err := meta.(*neon.Client).GetProjectBranch(d.Get("project_id").(string), d.Id())
 	if err != nil {
 		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			tflog.Warn(ctx, "branch not found, removing from state", map[string]any{"id": d.Id()})
 			d.SetId("")
 			return nil
 		}

--- a/provider/resource_branch.go
+++ b/provider/resource_branch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -215,6 +216,10 @@ func resourceBranchRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	resp, err := meta.(*neon.Client).GetProjectBranch(d.Get("project_id").(string), d.Id())
 	if err != nil {
+		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/provider/resource_database.go
+++ b/provider/resource_database.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -98,6 +99,10 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Get("project_id").(string), d.Get("branch_id").(string), d.Get("name").(string),
 	)
 	if err != nil {
+		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/provider/resource_database.go
+++ b/provider/resource_database.go
@@ -100,6 +100,7 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 	)
 	if err != nil {
 		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			tflog.Warn(ctx, "database not found, removing from state", map[string]any{"id": d.Id()})
 			d.SetId("")
 			return nil
 		}

--- a/provider/resource_endpoint.go
+++ b/provider/resource_endpoint.go
@@ -245,6 +245,7 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 	)
 	if err != nil {
 		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			tflog.Warn(ctx, "endpoint not found, removing from state", map[string]any{"id": d.Id()})
 			d.SetId("")
 			return nil
 		}

--- a/provider/resource_endpoint.go
+++ b/provider/resource_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -243,6 +244,10 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Id(),
 	)
 	if err != nil {
+		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -940,6 +940,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 	resp, err := client.GetProject(d.Id())
 	if err != nil {
 		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			tflog.Warn(ctx, "project not found, removing from state", map[string]any{"id": d.Id()})
 			d.SetId("")
 			return nil
 		}

--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
@@ -938,6 +939,10 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	resp, err := client.GetProject(d.Id())
 	if err != nil {
+		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/provider/resource_project_test.go
+++ b/provider/resource_project_test.go
@@ -789,3 +789,29 @@ func Test_resourceProjectUpdate_requestBody_block_vpc_connections(t *testing.T) 
 		assert.True(t, *reqUpdate.Project.Settings.BlockVpcConnections)
 	})
 }
+
+func Test_resourceProjectRead(t *testing.T) {
+	if os.Getenv("TF_ACC") == "1" {
+		t.Skip("acceptance tests are running")
+	}
+
+	t.Parallel()
+
+	t.Run("shall remove resource from state when project returns 404", func(t *testing.T) {
+		meta := &sdkClientStub{
+			err: neon.Error{HTTPCode: 404},
+		}
+
+		resource := resourceProject()
+		d := resource.TestResourceData()
+		if err := d.Set("name", "foo"); err != nil {
+			t.Fatal(err)
+		}
+		d.SetId("nonexistent-project-id")
+
+		err := resourceProjectRead(context.TODO(), d, meta)
+
+		assert.NoError(t, err)
+		assert.Empty(t, d.Id())
+	})
+}

--- a/provider/resource_role.go
+++ b/provider/resource_role.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -122,6 +123,10 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	resp, err := meta.(*neon.Client).GetProjectBranchRole(projectID, branchID, name)
 	if err != nil {
+		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
@@ -129,6 +134,10 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if role.Password == nil {
 		r, err := meta.(*neon.Client).GetProjectBranchRolePassword(projectID, branchID, name)
 		if err != nil {
+			if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
 			return err
 		}
 		role.Password = pointer(r.Password)

--- a/provider/resource_role.go
+++ b/provider/resource_role.go
@@ -124,6 +124,7 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	resp, err := meta.(*neon.Client).GetProjectBranchRole(projectID, branchID, name)
 	if err != nil {
 		if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+			tflog.Warn(ctx, "role not found, removing from state", map[string]any{"id": d.Id()})
 			d.SetId("")
 			return nil
 		}
@@ -135,6 +136,7 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		r, err := meta.(*neon.Client).GetProjectBranchRolePassword(projectID, branchID, name)
 		if err != nil {
 			if neonErr, ok := err.(neon.Error); ok && neonErr.HTTPCode == http.StatusNotFound {
+				tflog.Warn(ctx, "role password not found, removing from state", map[string]any{"id": d.Id()})
 				d.SetId("")
 				return nil
 			}

--- a/provider/stub.go
+++ b/provider/stub.go
@@ -44,7 +44,7 @@ func (s *sdkClientStub) UpdateProject(_ string, cfg neon.ProjectUpdateRequest) (
 }
 
 func (s *sdkClientStub) GetProject(_ string) (neon.ProjectResponse, error) {
-	return neon.ProjectResponse{}, nil
+	return neon.ProjectResponse{}, s.err
 }
 
 func (s *sdkClientStub) ListProjectBranches(_ string, _ *string, _ *string, _ *string, _ *string, _ *int) (neon.ListProjectBranchesRespObj, error) {


### PR DESCRIPTION
When a Neon project (or any of its child resources) is deleted outside Terraform (via the Neon console or API) the provider returns a hard error on the next plan or apply rather than gracefully handling the missing resource:

```
Error: error reading Neon project <project-id>
  404: project not found
```
This is inconsistent with the standard Terraform provider convention: a 404 during a Read should remove the resource from state and let Terraform propose recreation on the next apply.

## Changes
Added 404 detection to the Read function of every resource that has a direct parent–child relationship with a project. When the Neon API returns HTTP 404, the provider now calls d.SetId("") and returns nil, which signals to Terraform that the resource no longer exists externally.