### PR TITLE
fix: allow suspend_timeout_seconds = -1 in project default_endpoint_settings

### DIFF
--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -326,10 +326,8 @@ var schemaDefaultEndpointSettings = &schema.Schema{
 				Optional: true,
 				Computed: true,
 				ValidateFunc: func(v interface{}, s string) (warn []string, errs []error) {
-					switch vv, ok := v.(int); ok {
-					case vv == -1:
-					default:
-						warn, errs = intValidationNotNegative(v, s)
+					if vv, ok := v.(int); ok && vv < -1 {
+						errs = append(errs, fmt.Errorf("%s must be -1 (never suspend) or a non-negative integer, got: %d", s, vv))
 					}
 					return warn, errs
 				},
@@ -352,7 +350,7 @@ func mapToDefaultEndpointsSettings(v map[string]interface{}) *neon.DefaultEndpoi
 		o.AutoscalingLimitMaxCu = pointer(neon.ComputeUnit(v))
 	}
 
-	if v, ok := v["suspend_timeout_seconds"].(int); ok && v > 0 {
+	if v, ok := v["suspend_timeout_seconds"].(int); ok && v != 0 {
 		o.SuspendTimeoutSeconds = pointer(neon.SuspendTimeoutSeconds(v))
 	}
 	return &o

--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -326,8 +326,10 @@ var schemaDefaultEndpointSettings = &schema.Schema{
 				Optional: true,
 				Computed: true,
 				ValidateFunc: func(v interface{}, s string) (warn []string, errs []error) {
-					if vv, ok := v.(int); ok && vv < -1 {
-						errs = append(errs, fmt.Errorf("%s must be -1 (never suspend) or a non-negative integer, got: %d", s, vv))
+					switch vv, ok := v.(int); ok {
+					case vv == -1:
+					default:
+						warn, errs = intValidationNotNegative(v, s)
 					}
 					return warn, errs
 				},

--- a/provider/resource_project_test.go
+++ b/provider/resource_project_test.go
@@ -643,9 +643,11 @@ func Test_resourceProjectDefaultEndpointSettingsShallAllowToSetSuspensionTimeout
 		in      int
 		isError bool
 	}{
-		"no suspension": {-1, false},
-		"invalid":       {-2, true},
-		"valid":         {300, false},
+		"never suspend (-1) is allowed":      {-1, false},
+		"negative other than -1 is rejected": {-2, true},
+		"large negative is rejected":         {-300, true},
+		"zero is allowed":                    {0, false},
+		"positive is allowed":                {300, false},
 	}
 	t.Parallel()
 	for name, test := range tests {

--- a/provider/resource_project_test.go
+++ b/provider/resource_project_test.go
@@ -662,6 +662,35 @@ func Test_resourceProjectDefaultEndpointSettingsShallAllowToSetSuspensionTimeout
 	}
 }
 
+func Test_mapToDefaultEndpointsSettings_suspendTimeoutSeconds(t *testing.T) {
+	tests := map[string]struct {
+		in   int
+		want *neon.SuspendTimeoutSeconds
+	}{
+		"never suspend": {
+			in:   -1,
+			want: pointer(neon.SuspendTimeoutSeconds(-1)),
+		},
+		"custom timeout": {
+			in:   300,
+			want: pointer(neon.SuspendTimeoutSeconds(300)),
+		},
+		"zero is skipped": {
+			in:   0,
+			want: nil,
+		},
+	}
+	t.Parallel()
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mapToDefaultEndpointsSettings(map[string]interface{}{
+				"suspend_timeout_seconds": tt.in,
+			})
+			assert.Equal(t, tt.want, got.SuspendTimeoutSeconds)
+		})
+	}
+}
+
 func Test_resourceProjectCreate_requestBody_block_vpc_connections(t *testing.T) {
 	T := pointer(true)
 	F := pointer(false)


### PR DESCRIPTION
In `neon_project` resource `default_endpoint_settings` block, `suspend_timeout_seconds` = -1 (never
suspend) was accepted by schema validation but dropped when building the API request because
`mapToDefaultEndpointsSettings` only forwarded values > 0.

Fix the mapper to forward any non-zero value. Improve validation errors for values below -1.

Large computes (>=18 CU) require scale-to-zero to be disabled; setting `suspend_timeout_seconds` to
-1 in the `default_endpoint_settings` block supports that use case.
