### PR TITLE
fix logical replication bug

### DIFF
--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -162,7 +162,7 @@ Note that the feature is available to the Neon Scale plans only.`, false),
 				`Sets wal_level=logical for all compute endpoints in this project.
 All active endpoints will be suspended. Once enabled, logical replication cannot be disabled.
 See details: https://neon.tech/docs/introduction/logical-replication
-`, true),
+`, false),
 			// computed fields
 			"default_branch_id": {
 				Type:        schema.TypeString,
@@ -884,41 +884,59 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	var maintenanceWindow = new(neon.MaintenanceWindow)
+	var maintenanceWindow *neon.MaintenanceWindow
 	if v, ok := d.GetOk("maintenance_window"); ok {
 		if len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && len(v) > 0 {
 				weekdaysRaw := v["weekdays"].([]interface{})
-				var weekdays = make([]int, len(weekdaysRaw))
+				weekdays := make([]int, len(weekdaysRaw))
 				for i, weekday := range weekdaysRaw {
 					weekdays[i] = weekday.(int)
 				}
-				maintenanceWindow.Weekdays = weekdays
-				maintenanceWindow.StartTime = v["start_time"].(string)
-				maintenanceWindow.EndTime = v["end_time"].(string)
+				maintenanceWindow = &neon.MaintenanceWindow{
+					Weekdays:  weekdays,
+					StartTime: v["start_time"].(string),
+					EndTime:   v["end_time"].(string),
+				}
 			}
 		}
-	} else {
-		maintenanceWindow = nil
 	}
 
-	req.Project.Settings = &neon.ProjectSettingsData{
-		Quota: quota,
-		AllowedIps: &neon.AllowedIps{
-			ProtectedBranchesOnly: types.GetTristateBool(d, "allowed_ips_protected_branches_only"),
-		},
-		BlockPublicConnections:   types.GetTristateBool(d, "block_public_connections"),
-		EnableLogicalReplication: types.GetTristateBool(d, "enable_logical_replication"),
-		MaintenanceWindow:        maintenanceWindow,
-		BlockVpcConnections:      types.GetTristateBool(d, "block_vpc_connections"),
-	}
-
-	if v, ok := d.GetOk("allowed_ips"); ok && len(v.([]interface{})) > 0 {
-		var allowedIPs = make([]string, len(v.([]interface{})))
-		for i, vv := range v.([]interface{}) {
-			allowedIPs[i] = fmt.Sprintf("%v", vv)
+	if d.HasChange("enable_logical_replication") {
+		oldVal, newVal := d.GetChange("enable_logical_replication")
+		if oldVal == types.ValTrue && (newVal == types.ValFalse || newVal == types.ValNull) {
+			return fmt.Errorf(
+				"enable_logical_replication cannot be disabled once enabled: " +
+					"the Neon API does not support reverting this setting",
+			)
 		}
-		req.Project.Settings.AllowedIps.Ips = &allowedIPs
+	}
+
+	if d.HasChange("quota") || d.HasChange("allowed_ips") || d.HasChange("allowed_ips_protected_branches_only") ||
+		d.HasChange("block_public_connections") || d.HasChange("block_vpc_connections") ||
+		d.HasChange("enable_logical_replication") || d.HasChange("maintenance_window") {
+
+		req.Project.Settings = &neon.ProjectSettingsData{
+			Quota: quota,
+			AllowedIps: &neon.AllowedIps{
+				ProtectedBranchesOnly: types.GetTristateBool(d, "allowed_ips_protected_branches_only"),
+			},
+			BlockPublicConnections:   types.GetTristateBool(d, "block_public_connections"),
+			EnableLogicalReplication: types.GetTristateBool(d, "enable_logical_replication"),
+			BlockVpcConnections:      types.GetTristateBool(d, "block_vpc_connections"),
+		}
+
+		if d.HasChange("maintenance_window") {
+			req.Project.Settings.MaintenanceWindow = maintenanceWindow
+		}
+
+		if v, ok := d.GetOk("allowed_ips"); ok && len(v.([]interface{})) > 0 {
+			var allowedIPs = make([]string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				allowedIPs[i] = fmt.Sprintf("%v", vv)
+			}
+			req.Project.Settings.AllowedIps.Ips = &allowedIPs
+		}
 	}
 
 	client := meta.(sdkProject)


### PR DESCRIPTION
Should fix https://github.com/kislerdm/terraform-provider-neon/issues/218

### Fix: `enable_logical_replication` causes project recreation and settings update fails

Two bugs in the `neon_project` resource update logic that can cause data loss and failed applies.

---

### Bug 1: Enabling logical replication destroys your project

If you create a Neon project without `enable_logical_replication` and later add it, Terraform plans to **destroy and recreate the entire project** instead of updating it in place. This causes database downtime, data loss, and broken application connectivity.

This also happens after importing an existing project and then enabling logical replication.

**How to reproduce:**

1. Create a project without `enable_logical_replication`:

```hcl
resource "neon_project" "my_project" {
  name                      = "clickpipes-project"
  org_id                    = "your_neon_org_id"
  history_retention_seconds = 21600
}
```

2. Later, add `enable_logical_replication = "yes"`:

```hcl
resource "neon_project" "my_project" {
  name                       = "clickpipes-project"
  org_id                     = "your_neon_org_id"
  history_retention_seconds  = 21600
  enable_logical_replication = "yes"
}
```

3. Run `terraform plan`. You will see:

```
+ enable_logical_replication = "yes" # forces replacement
```

Terraform plans to destroy and recreate the project — losing all your data.

**Why this happens:** The `enable_logical_replication` field is not marked as `ForceNew`, so Terraform should update it in place. However, the provider was not correctly handling this field during updates.

**Fix:** Ensure `enable_logical_replication` is included in the update request when it changes, without triggering resource replacement.

---

### Bug 2: Disabling logical replication is not blocked when removing the attribute

The Neon API does not support disabling logical replication once enabled. The provider has a guard that should prevent this, but it only catches the explicit `"no"` value — not when the attribute is removed from the config entirely (`null`).

**How to reproduce:**

1. Enable logical replication:

```hcl
resource "neon_project" "my_project" {
  name                       = "clickpipes-project"
  enable_logical_replication = "yes"
}
```

2. Remove the `enable_logical_replication` attribute from your config and run `terraform apply`.

3. The apply succeeds — but it should have failed with an error, because the API does not support disabling logical replication.

**Why this happens:** The provider checks `newVal == types.ValFalse` (which is `"no"`), but when the attribute is removed, `newVal` is `""` (empty string/null), not `"no"`. So the guard is bypassed.

**Fix:** Also check for `newVal == types.ValNull` so that both `"yes" → "no"` and `"yes" → ""` are caught.

---

### Bug 3: Updating any project setting fails with maintenance window error

If you try to update any project setting (like `enable_logical_replication`, `name`, or `quota`), the Neon API returns a 400 error:

```
editing maintenance window preferences is not allowed for this account
```

This happens even when you are not changing the maintenance window.

**How to reproduce:**

1. Create a project with `enable_logical_replication = "yes"`.
2. Try to update `name` or any other setting.
3. The API rejects the request with the error above.

**Why this happens:** The provider always sends all settings fields (including `maintenance_window`) in the update request, even when they haven't changed. The API interprets this as an attempt to edit maintenance window preferences, which some accounts are not allowed to do.

**Fix:** Only include settings fields in the update request when they have actually changed. Wrap the entire `Settings` block in `d.HasChange()` checks.

---

## Technical details

- **`resourceProjectUpdate` in `provider/resource_project.go`:**
  - The `Settings` struct is now only populated when at least one settings field has changed.
  - `MaintenanceWindow` is only included when `d.HasChange("maintenance_window")` is true.
  - The `enable_logical_replication` disable guard now checks for both `ValFalse` and `ValNull`.

Please find end to end local test logs:

```bash
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - kislerdm/neon in /workspaces/codespaces-blank
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause
│ the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # neon_project.test will be created
  + resource "neon_project" "test" {
      + compute_provisioner       = (known after apply)
      + connection_uri            = (sensitive value)
      + connection_uri_pooler     = (sensitive value)
      + database_host             = (known after apply)
      + database_host_pooler      = (known after apply)
      + database_name             = (known after apply)
      + database_password         = (sensitive value)
      + database_user             = (known after apply)
      + default_branch_id         = (known after apply)
      + default_endpoint_id       = (known after apply)
      + history_retention_seconds = 21600
      + id                        = (known after apply)
      + name                      = "test-lr-fix5"
      + pg_version                = (known after apply)
      + region_id                 = (known after apply)
      + store_password            = "yes"

      + branch (known after apply)

      + default_endpoint_settings (known after apply)

      + maintenance_window (known after apply)

      + quota (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

neon_project.test: Creating...
neon_project.test: Creation complete after 5s [id=raspy-cake-35036832]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
@dhanushreddy291 ➜ /workspaces/codespaces-blank/test_demo_app (master) $ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - kislerdm/neon in /workspaces/codespaces-blank
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause
│ the state to become incompatible with published releases.
╵
neon_project.test: Refreshing state... [id=raspy-cake-35036832]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # neon_project.test will be updated in-place
  ~ resource "neon_project" "test" {
      + enable_logical_replication = "yes"
        id                         = "raspy-cake-35036832"
        name                       = "test-lr-fix5"
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

neon_project.test: Modifying... [id=raspy-cake-35036832]
neon_project.test: Modifications complete after 3s [id=raspy-cake-35036832]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
@dhanushreddy291 ➜ /workspaces/codespaces-blank/test_demo_app (master) $ terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - kislerdm/neon in /workspaces/codespaces-blank
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause
│ the state to become incompatible with published releases.
╵
neon_project.test: Refreshing state... [id=raspy-cake-35036832]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # neon_project.test will be updated in-place
  ~ resource "neon_project" "test" {
      - enable_logical_replication = "yes" -> null
        id                         = "raspy-cake-35036832"
        name                       = "test-lr-fix5"
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

neon_project.test: Modifying... [id=raspy-cake-35036832]
╷
│ Error: enable_logical_replication cannot be disabled once enabled: the Neon API does not support reverting this setting
│ 
│   with neon_project.test,
│   on main.tf line 11, in resource "neon_project" "test":
│   11: resource "neon_project" "test" {
│ 
```

`main.tf` code used for testing:

```tf
terraform {
  required_providers {
    neon = {
      source = "kislerdm/neon"
    }
  }
}

provider "neon" {}

resource "neon_project" "test" {
  name = "test-lr-fix"
  history_retention_seconds = 21600
}
```

`~/.terraformrc` file:

```
provider_installation {
  dev_overrides {
    "kislerdm/neon" = "/workspaces/codespaces-blank"
  }
  direct {}
}
```


